### PR TITLE
Improve constraints, bump -functors for `Compose` fix, remove StrongCheck/generated stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ import Text.Markdown.SlamDown.Pretty
 Module documentation is [published on
 Pursuit](http://pursuit.purescript.org/packages/purescript-markdown).
 
-### Tests
-
-The tests use [purescript-strongcheck](http://github.com/purescript-contrib/purescript-strongcheck) to verify that an arbitrary `SlamDown` document can be rendered as a `String` and then parsed to a `SlamDown` equal to the original.
-
 ## Features
 
 In general, SlamDown is a subset of [CommonMark](http://spec.commonmark.org/), supporting the following features:

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "purescript-const": "^4.0.0",
     "purescript-datetime": "^4.0.0",
-    "purescript-functors": "^3.0.0",
+    "purescript-functors": "^3.0.1",
     "purescript-lists": "^5.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "purescript-parsing": "^5.0.1",

--- a/bower.json
+++ b/bower.json
@@ -32,8 +32,10 @@
     "purescript-precise": "^3.0.1",
     "purescript-prelude": "^4.0.1",
     "purescript-strings": "^4.0.0",
-    "purescript-strongcheck": "^4.1.1",
     "purescript-unicode": "^4.0.1",
     "purescript-validation": "^4.0.0"
+  },
+  "devDependencies": {
+    "purescript-assert": "^4.0.0"
   }
 }

--- a/src/Text/Markdown/SlamDown/Syntax.purs
+++ b/src/Text/Markdown/SlamDown/Syntax.purs
@@ -12,8 +12,6 @@ import Prelude
 import Data.Eq (class Eq1)
 import Data.List as L
 import Data.Ord (class Ord1)
-import Test.StrongCheck.Arbitrary as SCA
-import Test.StrongCheck.Gen as Gen
 import Text.Markdown.SlamDown.Syntax.Block (Block(..), CodeBlockType(..), ListType(..)) as SDB
 import Text.Markdown.SlamDown.Syntax.FormField (class Value, Expr(..), FormField, FormFieldP(..), TextBox(..), TimePrecision(..), getLiteral, getUnevaluated, renderValue, stringValue, transFormField, transTextBox, traverseFormField, traverseTextBox) as SDF
 import Text.Markdown.SlamDown.Syntax.Inline (Inline(..), LinkTarget(..)) as SDI
@@ -36,6 +34,3 @@ derive instance ord1SlamDownP ∷ Ord1 SlamDownP
 
 derive newtype instance semigroupSlamDownP ∷ Semigroup (SlamDownP a)
 derive newtype instance monoidSlamDownP ∷ Monoid (SlamDownP a)
-
-instance arbitrarySlamDownP ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (SlamDownP a) where
-  arbitrary = SlamDown <<< L.fromFoldable <$> Gen.arrayOf SCA.arbitrary

--- a/src/Text/Markdown/SlamDown/Syntax.purs
+++ b/src/Text/Markdown/SlamDown/Syntax.purs
@@ -9,33 +9,33 @@ module Text.Markdown.SlamDown.Syntax
 
 import Prelude
 
+import Data.Eq (class Eq1)
 import Data.List as L
+import Data.Ord (class Ord1)
 import Test.StrongCheck.Arbitrary as SCA
 import Test.StrongCheck.Gen as Gen
-
 import Text.Markdown.SlamDown.Syntax.Block (Block(..), CodeBlockType(..), ListType(..)) as SDB
 import Text.Markdown.SlamDown.Syntax.FormField (class Value, Expr(..), FormField, FormFieldP(..), TextBox(..), TimePrecision(..), getLiteral, getUnevaluated, renderValue, stringValue, transFormField, transTextBox, traverseFormField, traverseTextBox) as SDF
 import Text.Markdown.SlamDown.Syntax.Inline (Inline(..), LinkTarget(..)) as SDI
 
 -- | `SlamDownP` is the type of SlamDown abstract syntax trees which take values in `a`.
-data SlamDownP a = SlamDown (L.List (SDB.Block a))
+newtype SlamDownP a = SlamDown (L.List (SDB.Block a))
 
 type SlamDown = SlamDownP String
 
-instance functorSlamDownP ∷ Functor SlamDownP where
-  map f (SlamDown bs) = SlamDown (map f <$> bs)
+derive instance functorSlamDownP ∷ Functor SlamDownP
 
 instance showSlamDownP ∷ (Show a) ⇒ Show (SlamDownP a) where
   show (SlamDown bs) = "(SlamDown " <> show bs <> ")"
 
-derive instance eqSlamDownP ∷ (Eq a, Ord a) ⇒ Eq (SlamDownP a)
-derive instance ordSlamDownP ∷ (Eq a, Ord a) ⇒ Ord (SlamDownP a)
+derive newtype instance eqSlamDownP ∷ Eq a ⇒ Eq (SlamDownP a)
+derive instance eq1SlamDownP ∷ Eq1 SlamDownP
 
-instance semigroupSlamDownP ∷ Semigroup (SlamDownP a) where
-  append (SlamDown bs1) (SlamDown bs2) = SlamDown (bs1 <> bs2)
+derive newtype instance ordSlamDownP ∷ Ord a ⇒ Ord (SlamDownP a)
+derive instance ord1SlamDownP ∷ Ord1 SlamDownP
 
-instance monoidSlamDownP ∷ Monoid (SlamDownP a) where
-  mempty = SlamDown mempty
+derive newtype instance semigroupSlamDownP ∷ Semigroup (SlamDownP a)
+derive newtype instance monoidSlamDownP ∷ Monoid (SlamDownP a)
 
 instance arbitrarySlamDownP ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (SlamDownP a) where
   arbitrary = SlamDown <<< L.fromFoldable <$> Gen.arrayOf SCA.arbitrary

--- a/src/Text/Markdown/SlamDown/Syntax/Block.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Block.purs
@@ -9,8 +9,6 @@ import Prelude
 import Data.Eq (class Eq1)
 import Data.List as L
 import Data.Ord (class Ord1)
-import Test.StrongCheck.Arbitrary as SCA
-import Test.StrongCheck.Gen as Gen
 import Text.Markdown.SlamDown.Syntax.Inline (Inline)
 
 data Block a
@@ -38,22 +36,6 @@ derive instance eq1Block ∷ Eq1 Block
 derive instance ordBlock ∷ Ord a ⇒ Ord (Block a)
 derive instance ord1Block ∷ Ord1 Block
 
--- | Nota bene: this does not generate any recursive structure
-instance arbitraryBlock ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (Block a) where
-  arbitrary = do
-    k ← Gen.chooseInt 0 6
-    case k of
-      0 → Paragraph <$> listOf SCA.arbitrary
-      1 → Header <$> SCA.arbitrary <*> listOf SCA.arbitrary
-      2 → pure $ Blockquote L.Nil
-      3 → Lst <$> SCA.arbitrary <*> listOf (pure L.Nil)
-      4 → CodeBlock <$> SCA.arbitrary <*> listOf SCA.arbitrary
-      5 → LinkReference <$> SCA.arbitrary <*> SCA.arbitrary
-      _ → pure Rule
-
-listOf ∷ ∀ f a. (Monad f) ⇒ Gen.GenT f a → Gen.GenT f (L.List a)
-listOf = map L.fromFoldable <<< Gen.arrayOf
-
 data ListType
   = Bullet String
   | Ordered String
@@ -65,11 +47,6 @@ instance showListType ∷ Show ListType where
 derive instance eqListType ∷ Eq ListType
 derive instance ordListType ∷ Ord ListType
 
-instance arbitraryListType ∷ SCA.Arbitrary ListType where
-  arbitrary = do
-    b ← SCA.arbitrary
-    if b then Bullet <$> SCA.arbitrary else Ordered <$> SCA.arbitrary
-
 data CodeBlockType
   = Indented
   | Fenced Boolean String
@@ -80,8 +57,3 @@ instance showCodeBlockType ∷ Show CodeBlockType where
 
 derive instance eqCodeBlockType ∷ Eq CodeBlockType
 derive instance ordCodeBlockType ∷ Ord CodeBlockType
-
-instance arbitraryCodeBlockType ∷ SCA.Arbitrary CodeBlockType where
-  arbitrary = do
-    b ← SCA.arbitrary
-    if b then pure Indented else Fenced <$> SCA.arbitrary <*> SCA.arbitrary

--- a/src/Text/Markdown/SlamDown/Syntax/Block.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Block.purs
@@ -6,11 +6,11 @@ module Text.Markdown.SlamDown.Syntax.Block
 
 import Prelude
 
+import Data.Eq (class Eq1)
 import Data.List as L
-
+import Data.Ord (class Ord1)
 import Test.StrongCheck.Arbitrary as SCA
 import Test.StrongCheck.Gen as Gen
-
 import Text.Markdown.SlamDown.Syntax.Inline (Inline)
 
 data Block a
@@ -22,18 +22,9 @@ data Block a
   | LinkReference String String
   | Rule
 
-instance functorBlock ∷ Functor Block where
-  map f x =
-    case x of
-      Paragraph is → Paragraph (map f <$> is)
-      Header n is → Header n (map f <$> is)
-      Blockquote bs → Blockquote (map f <$> bs)
-      Lst ty bss → Lst ty (map (map f) <$> bss)
-      CodeBlock ty ss → CodeBlock ty ss
-      LinkReference l uri → LinkReference l uri
-      Rule → Rule
+derive instance functorBlock ∷ Functor Block
 
-instance showBlock ∷ (Show a) ⇒ Show (Block a) where
+instance showBlock ∷ Show a ⇒ Show (Block a) where
   show (Paragraph is) = "(Paragraph " <> show is <> ")"
   show (Header n is) = "(Header " <> show n <> " " <> show is <> ")"
   show (Blockquote bs) = "(Blockquote " <> show bs <> ")"
@@ -42,8 +33,10 @@ instance showBlock ∷ (Show a) ⇒ Show (Block a) where
   show (LinkReference l uri) = "(LinkReference " <> show l <> " " <> show uri <> ")"
   show Rule = "Rule"
 
-derive instance eqBlock ∷ (Eq a, Ord a) ⇒ Eq (Block a)
-derive instance ordBlock ∷ (Ord a) ⇒ Ord (Block a)
+derive instance eqBlock ∷ Eq a ⇒ Eq (Block a)
+derive instance eq1Block ∷ Eq1 Block
+derive instance ordBlock ∷ Ord a ⇒ Ord (Block a)
+derive instance ord1Block ∷ Ord1 Block
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryBlock ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (Block a) where

--- a/src/Text/Markdown/SlamDown/Syntax/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Inline.purs
@@ -9,8 +9,6 @@ import Data.Eq (class Eq1)
 import Data.List as L
 import Data.Maybe as M
 import Data.Ord (class Ord1)
-import Test.StrongCheck.Arbitrary as SCA
-import Test.StrongCheck.Gen as Gen
 import Text.Markdown.SlamDown.Syntax.FormField (FormField)
 
 data Inline a
@@ -46,23 +44,6 @@ derive instance eq1Inline ∷ Eq1 Inline
 derive instance ordInline ∷ Ord a ⇒ Ord (Inline a)
 derive instance ord1Inline ∷ Ord1 Inline
 
--- | Nota bene: this does not generate any recursive structure
-instance arbitraryInline ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (Inline a) where
-  arbitrary = do
-    k ← Gen.chooseInt 0 10
-    case k of
-      0 → Str <$> SCA.arbitrary
-      1 → Entity <$> SCA.arbitrary
-      2 → pure Space
-      3 → pure SoftBreak
-      4 → pure LineBreak
-      5 → Code <$> SCA.arbitrary <*> SCA.arbitrary
-      6 → FormField <$> SCA.arbitrary <*> SCA.arbitrary <*> SCA.arbitrary
-      7 → pure (Emph L.Nil)
-      8 → pure (Strong L.Nil)
-      9 → Link L.Nil <$> SCA.arbitrary
-      _ → Image L.Nil <$> SCA.arbitrary
-
 data LinkTarget
   = InlineLink String
   | ReferenceLink (M.Maybe String)
@@ -73,8 +54,3 @@ derive instance ordLinkTarget ∷ Ord LinkTarget
 instance showLinkTarget ∷ Show LinkTarget where
   show (InlineLink uri) = "(InlineLink " <> show uri <> ")"
   show (ReferenceLink tgt) = "(ReferenceLink " <> show tgt <> ")"
-
-instance arbitraryLinkTarget ∷ SCA.Arbitrary LinkTarget where
-  arbitrary = do
-    b ← SCA.arbitrary
-    if b then InlineLink <$> SCA.arbitrary else ReferenceLink <$> SCA.arbitrary

--- a/src/Text/Markdown/SlamDown/Syntax/Inline.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/Inline.purs
@@ -5,12 +5,12 @@ module Text.Markdown.SlamDown.Syntax.Inline
 
 import Prelude
 
+import Data.Eq (class Eq1)
 import Data.List as L
 import Data.Maybe as M
-
+import Data.Ord (class Ord1)
 import Test.StrongCheck.Arbitrary as SCA
 import Test.StrongCheck.Gen as Gen
-
 import Text.Markdown.SlamDown.Syntax.FormField (FormField)
 
 data Inline a
@@ -26,20 +26,7 @@ data Inline a
   | Image (L.List (Inline a)) String
   | FormField String Boolean (FormField a)
 
-instance functorInline ∷ Functor Inline where
-  map f =
-    case _ of
-      Str s → Str s
-      Entity s → Entity s
-      Space → Space
-      SoftBreak → SoftBreak
-      LineBreak → LineBreak
-      Emph is → Emph (map f <$> is)
-      Strong is → Strong (map f <$> is)
-      Code b s → Code b s
-      Link is tgt → Link (map f <$> is) tgt
-      Image is tgt → Image (map f <$> is) tgt
-      FormField str b ff → FormField str b (f <$> ff)
+derive instance functorInline ∷ Functor Inline
 
 instance showInline ∷ (Show a) ⇒ Show (Inline a) where
   show (Str s) = "(Str " <> show s <> ")"
@@ -54,8 +41,10 @@ instance showInline ∷ (Show a) ⇒ Show (Inline a) where
   show (Image is uri) = "(Image " <> show is <> " " <> show uri <> ")"
   show (FormField l r f) = "(FormField " <> show l <> " " <> show r <> " " <> show f <> ")"
 
-derive instance eqInline ∷ (Eq a, Ord a) ⇒ Eq (Inline a)
+derive instance eqInline ∷ Eq a ⇒ Eq (Inline a)
+derive instance eq1Inline ∷ Eq1 Inline
 derive instance ordInline ∷ Ord a ⇒ Ord (Inline a)
+derive instance ord1Inline ∷ Ord1 Inline
 
 -- | Nota bene: this does not generate any recursive structure
 instance arbitraryInline ∷ (SCA.Arbitrary a, Eq a) ⇒ SCA.Arbitrary (Inline a) where

--- a/src/Text/Markdown/SlamDown/Syntax/TextBox.purs
+++ b/src/Text/Markdown/SlamDown/Syntax/TextBox.purs
@@ -62,7 +62,7 @@ traverseTextBox eta = case _ of
   Time prec def → Time prec <$> eta def
   DateTime prec def → DateTime prec <$> eta def
 
-instance showTextBox ∷ (Functor f, Show (f String), Show (f HN.HugeNum), Show (f DT.Time), Show (f DT.Date), Show (f DT.DateTime)) ⇒ Show (TextBox f) where
+instance showTextBox ∷ (Show (f String), Show (f HN.HugeNum), Show (f DT.Time), Show (f DT.Date), Show (f DT.DateTime)) ⇒ Show (TextBox f) where
   show = case _ of
     PlainText def → "(PlainText " <> show def <> ")"
     Numeric def → "(Numeric " <> show def <> ")"
@@ -70,8 +70,8 @@ instance showTextBox ∷ (Functor f, Show (f String), Show (f HN.HugeNum), Show 
     Time prec def → "(Time " <> show prec <> " " <> show def <> ")"
     DateTime prec def → "(DateTime " <> show prec <> " " <> show def <> ")"
 
-derive instance eqTextBox ∷ (Functor f, Eq1 f) ⇒ Eq (TextBox f)
-derive instance ordTextBox ∷ (Functor f, Ord1 f) ⇒ Ord (TextBox f)
+derive instance eqTextBox ∷ Eq1 f ⇒ Eq (TextBox f)
+derive instance ordTextBox ∷ Ord1 f ⇒ Ord (TextBox f)
 
 instance arbitraryTextBox ∷ (Functor f, SCA.Arbitrary (f String), SCA.Arbitrary (f Number), SCA.Arbitrary (f ADT.ArbTime), SCA.Arbitrary (f ADT.ArbDate), SCA.Arbitrary (f ADT.ArbDateTime)) ⇒ SCA.Arbitrary (TextBox f) where
   arbitrary = do

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -2,10 +2,6 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Trampoline as Trampoline
-
-import Data.Array as A
-import Data.Char as CH
 import Data.DateTime as DT
 import Data.Either (Either(..), isLeft)
 import Data.Enum (toEnum)
@@ -14,50 +10,16 @@ import Data.Identity as ID
 import Data.List as L
 import Data.Maybe as M
 import Data.Newtype (un)
-import Data.String (trim) as S
-import Data.String.CodeUnits (fromCharArray, toCharArray) as S
-import Data.Traversable as TR
-
-import Data.Tuple (uncurry)
-
 import Effect (Effect)
 import Effect.Console as C
-
-import Text.Markdown.SlamDown.Syntax as SD
+import Partial.Unsafe (unsafePartial)
+import Test.Assert (assert, assertEqual)
 import Text.Markdown.SlamDown.Eval as SDE
 import Text.Markdown.SlamDown.Parser as SDP
 import Text.Markdown.SlamDown.Pretty as SDPR
+import Text.Markdown.SlamDown.Syntax as SD
 
-import Test.StrongCheck as SC
-import Test.StrongCheck.Arbitrary as SCA
-import Test.StrongCheck.Gen as Gen
-import Test.StrongCheck.LCG as LCG
-
-import Partial.Unsafe (unsafePartial)
-
-newtype NonEmptyString = NonEmptyString String
-derive instance eqNonEmptyString ∷ Eq NonEmptyString
-derive instance ordNonEmptyString ∷ Ord NonEmptyString
-
-genChar ∷ Gen.Gen Char
-genChar = Gen.elements '-' $ L.fromFoldable $ S.toCharArray "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 @!#$%^"
-
-instance arbitraryNonEmptyString ∷ SCA.Arbitrary NonEmptyString where
-  arbitrary =
-    Gen.arrayOf1 genChar
-      <#> uncurry A.cons
-      >>> S.fromCharArray
-      >>> S.trim
-      >>> NonEmptyString
-
-instance showNonEmptyString ∷ Show NonEmptyString where
-  show (NonEmptyString str) = str
-
-instance valueNonEmptyString ∷ SD.Value NonEmptyString where
-  stringValue = NonEmptyString
-  renderValue (NonEmptyString str) = str
-
-testDocument ∷ Either String (SD.SlamDownP NonEmptyString) → Effect Unit
+testDocument ∷ Either String (SD.SlamDownP String) → Effect Unit
 testDocument sd = do
   let printed = SDPR.prettyPrintMd <$> sd
       parsed = printed >>= SDP.parseMd
@@ -69,13 +31,13 @@ testDocument sd = do
     <> show printed
     <> "\nParsed:\n   "
     <> show parsed
-  SC.assert (parsed == sd SC.<?> "Test failed")
+  assertEqual { expected: parsed, actual: sd }
 
-failDocument ∷ Either String (SD.SlamDownP NonEmptyString) → Effect Unit
-failDocument sd = SC.assert (isLeft sd SC.<?> "Test failed")
+failDocument ∷ Either String (SD.SlamDownP String) → Effect Unit
+failDocument sd = assert (isLeft sd)
 
-static ∷ Effect Unit
-static = do
+main ∷ Effect Unit
+main = do
   testDocument $ SDP.parseMd "Paragraph"
   testDocument $ SDP.parseMd "Paragraph with spaces"
   testDocument $ SDP.parseMd "Paragraph with an entity: &copy;"
@@ -285,131 +247,3 @@ unsafeDate y m d = unsafePartial $ M.fromJust $ join $ DT.exactDate <$> toEnum y
 
 unsafeTime ∷ Int → Int → Int → DT.Time
 unsafeTime h m s = unsafePartial $ M.fromJust $ DT.Time <$> toEnum h <*> toEnum m <*> toEnum s <*> toEnum bottom
-
-generated ∷ Effect Unit
-generated = do
-  C.log "Random documents"
-  seed ← LCG.randomSeed
-  let
-    docs =
-      Trampoline.runTrampoline
-        $ Gen.sample'
-            10 (Gen.GenState { size: 10, seed })
-            (SDPR.prettyPrintMd <<< runTestSlamDown <$> SCA.arbitrary)
-
-  _ ← TR.traverse C.log docs
-
-  SC.quickCheck' 100 \(TestSlamDown sd) →
-    let
-      printed = SDPR.prettyPrintMd sd
-      parsed = SDP.parseMd printed
-    in parsed == (Right sd) SC.<?> "Pretty printer and parser incompatible for document: " <>
-      "\nOriginal: \n" <> show sd <>
-      "\nPrinted: \n" <> printed <>
-      "\nParsed: \n" <> show parsed
-  C.log "All dynamic passed"
-
-deferGen ∷ ∀ a. (Unit → Gen.Gen a) → Gen.Gen a
-deferGen g = do
-  u ← pure unit
-  g u
-
-tinyArrayOf ∷ ∀ a. Gen.Gen a → Gen.Gen (Array a)
-tinyArrayOf g = do
-  len ← Gen.chooseInt 0 1
-  Gen.vectorOf len g
-
-smallArrayOf ∷ ∀ a. Gen.Gen a → Gen.Gen (Array a)
-smallArrayOf g = do
-  len ← Gen.chooseInt 1 2
-  Gen.vectorOf len g
-
-newtype TestSlamDown = TestSlamDown (SD.SlamDownP NonEmptyString)
-
-runTestSlamDown ∷ TestSlamDown → SD.SlamDownP NonEmptyString
-runTestSlamDown (TestSlamDown sd) = sd
-
-instance arbSlamDown ∷ SCA.Arbitrary TestSlamDown where
-  arbitrary = (TestSlamDown <<< SD.SlamDown <<< L.fromFoldable) <$> blocks
-
-three ∷ ∀ a. a → a → a → Array a
-three a b c = [a, b, c]
-
-
-blocks ∷ ∀ a. SCA.Arbitrary a ⇒ SD.Value a ⇒ Gen.Gen (Array (SD.Block a))
-blocks =
-  Gen.oneOf (smallArrayOf block0)
-    [ A.singleton <$> bq
-    , A.singleton <$> list
-    , A.singleton <$> cb
-    ]
-  where
-  block0 ∷ Gen.Gen (SD.Block a)
-  block0 =
-    Gen.oneOf (SD.Paragraph <<< L.fromFoldable <$> inlines)
-      [ SD.Header <$> Gen.chooseInt 1 6 <*> (L.singleton <$> simpleText)
-      , SD.CodeBlock <$>
-        (SD.Fenced <$> (Gen.elements true (L.singleton false)) <*>
-         alphaNum)
-        <*> (L.fromFoldable <$> smallArrayOf alphaNum)
-      , SD.LinkReference <$> alphaNum <*> alphaNum
-      , pure SD.Rule
-      ]
-
-  bq ∷ Gen.Gen (SD.Block a)
-  bq = SD.Blockquote <$> (L.singleton <$> block0)
-
-  cb ∷ Gen.Gen (SD.Block a)
-  cb = SD.CodeBlock SD.Indented <<< L.fromFoldable <$> smallArrayOf alphaNum
-
-  list ∷ Gen.Gen (SD.Block a)
-  list =
-    SD.Lst
-      <$> Gen.oneOf (SD.Bullet <$> (Gen.elements "-" $ L.fromFoldable ["+", "*"])) [ SD.Ordered <$> (Gen.elements ")" $ L.singleton ".")]
-      <*> (L.fromFoldable <$> tinyArrayOf (L.fromFoldable <$> (tinyArrayOf block0)))
-
-inlines ∷ ∀ a. SCA.Arbitrary a ⇒ SD.Value a ⇒ Gen.Gen (Array (SD.Inline a))
-inlines =
-  Gen.oneOf inlines0
-    [ A.singleton <$> link
-    , A.singleton <$> formField
-    ]
-  where
-  inlines0 ∷ Gen.Gen (Array (SD.Inline a))
-  inlines0 =
-    Gen.oneOf (A.singleton <$> simpleText)
-     [ three
-         <$> simpleText
-         <*> (Gen.elements SD.Space $ L.fromFoldable [SD.SoftBreak, SD.LineBreak])
-         <*> simpleText
-     , A.singleton <$> (SD.Code <$> (Gen.elements true (L.singleton false)) <*> alphaNum)
-     ]
-
-  link ∷ Gen.Gen (SD.Inline a)
-  link = SD.Link <$> (L.fromFoldable <$> inlines0) <*> linkTarget
-
-  linkTarget ∷ Gen.Gen SD.LinkTarget
-  linkTarget =
-    Gen.oneOf (SD.InlineLink <$> alphaNum)
-      [ SD.ReferenceLink <<< M.Just <$> alphaNum ]
-
-  formField ∷ Gen.Gen (SD.Inline a)
-  formField =
-    SD.FormField
-      <$> alphaNum
-      <*> Gen.elements true (L.singleton false)
-      <*> SCA.arbitrary
-
-simpleText ∷ ∀ a. Gen.Gen (SD.Inline a)
-simpleText = SD.Str <$> alphaNum
-
-alphaNum ∷ Gen.Gen String
-alphaNum = do
-  len ← Gen.chooseInt 5 10
-  S.fromCharArray <$> Gen.vectorOf len (Gen.elements (unsafePartial $ M.fromJust $ CH.fromCharCode 97) $ L.fromFoldable (S.toCharArray "qwertyuioplkjhgfdszxcvbnm123457890ąćęóśźżĄĆĘÓŚŹŻ"))
-
-
-main ∷ Effect Unit
-main = do
-  static
-  generated


### PR DESCRIPTION
The constraint stuff should be reasonably self explanatory.

I removed SC/generated tests because they were bad tests anyway: they mostly didn't pass, as it's not possible to have roundtripping markdown for any random representation, due to ambiguities in the grammar. We probably could make it work, but would have to figure out how to make it impossible to represent un-roundtrippable things in the AST, which isn't really worth it.